### PR TITLE
fix(#40): Fix Collection.seasons interface type

### DIFF
--- a/src/interfaces/Collection.ts
+++ b/src/interfaces/Collection.ts
@@ -9,7 +9,7 @@ export interface Collection {
     properties: {
         tiers: string[];
         types: string[];
-        seasons: string;
+        seasons: string[];
         gameIds: number[];
         teamIds: number[];
     };


### PR DESCRIPTION
BREAKING CHANGE: `Collection.properties.seasons` is now an array of strings