### PR TITLE
fix: Fix field retrieved from API to get the market hour price

### DIFF
--- a/src/client/utils/Market.ts
+++ b/src/client/utils/Market.ts
@@ -16,9 +16,9 @@ export default class MarketUtils {
                 value: listing.previousAvgPrice?.statValue ?? null,
                 date: DateUtils.convertToDate(listing.previousAvgPrice?.statDate ?? null),
             },
-            currentAvgHourPrice: {
-                value: listing.currentAvgHourPrice?.statValue ?? null,
-                date: DateUtils.convertToDate(listing.currentAvgHourPrice?.statDate ?? null),
+            currentHourPrice: {
+                value: listing.currentHourPrice?.statValue ?? null,
+                date: DateUtils.convertToDate(listing.currentHourPrice?.statDate ?? null),
             },
 
             createdAt: new Date(listing.created),

--- a/src/client/utils/Market.ts
+++ b/src/client/utils/Market.ts
@@ -16,7 +16,8 @@ export default class MarketUtils {
                 value: listing.previousAvgPrice?.statValue ?? null,
                 date: DateUtils.convertToDate(listing.previousAvgPrice?.statDate ?? null),
             },
-            currentHourPrice: {
+            // @TODO rename to currentHourPrice to stick to the API contract
+            currentAvgHourPrice: {
                 value: listing.currentHourPrice?.statValue ?? null,
                 date: DateUtils.convertToDate(listing.currentHourPrice?.statDate ?? null),
             },

--- a/src/interfaces/MarketListing.ts
+++ b/src/interfaces/MarketListing.ts
@@ -6,7 +6,7 @@ export interface MarketListing {
 
     price: number;
     previousAvgPrice: AveragePrice;
-    currentAvgHourPrice: AveragePrice;
+    currentHourPrice: AveragePrice;
 
     createdAt: Date | null;
 

--- a/src/interfaces/MarketListing.ts
+++ b/src/interfaces/MarketListing.ts
@@ -6,7 +6,8 @@ export interface MarketListing {
 
     price: number;
     previousAvgPrice: AveragePrice;
-    currentHourPrice: AveragePrice;
+    // @TODO rename to currentHourPrice to stick to the API contract
+    currentAvgHourPrice: AveragePrice;
 
     createdAt: Date | null;
 


### PR DESCRIPTION
`MarketListing.currentAvgHourPrice` field does not longer exist on API and was replaced by `MarketListing.currentHourPrice`.

To test it:
```
epics.Market.getListings(829, 1, "price", "card")
.then(listings => console.log(listings[0].currentAvgHourPrice))
```
This should output `{ value: 195, date: 2020-04-26T16:00:00.000Z }`, actually outputs `{ value: null, date: null }`