### PR TITLE
fix: Handle pack and sticker market listings

### DIFF
--- a/src/client/utils/Market.ts
+++ b/src/client/utils/Market.ts
@@ -2,13 +2,15 @@ import { MarketListing } from '../../interfaces/MarketListing';
 import CardUtils from './Card';
 
 import DateUtils from './Date';
+import PackUtils from './Pack';
+import StickerUtils from './Sticker';
 
 /**
  * @hidden
  */
 export default class MarketUtils {
     public static createMarketListing(listing: any): MarketListing {
-        return {
+        const marketListing: MarketListing = {
             marketId: listing.marketId,
 
             price: listing.price,
@@ -24,7 +26,12 @@ export default class MarketUtils {
             createdAt: new Date(listing.created),
 
             type: listing.type,
-            card: CardUtils.createCard(listing.card),
         };
+
+        if (listing.card) marketListing.card = CardUtils.createCard(listing.card);
+        if (listing.pack) marketListing.pack = PackUtils.createPack(listing.pack.packTemplate);
+        if (listing.sticker) marketListing.sticker = StickerUtils.createSticker(listing.sticker);
+
+        return marketListing;
     }
 }

--- a/src/client/utils/Market.ts
+++ b/src/client/utils/Market.ts
@@ -1,9 +1,9 @@
 import { MarketListing } from '../../interfaces/MarketListing';
 import CardUtils from './Card';
-
-import DateUtils from './Date';
 import PackUtils from './Pack';
 import StickerUtils from './Sticker';
+
+import DateUtils from './Date';
 
 /**
  * @hidden

--- a/src/interfaces/MarketListing.ts
+++ b/src/interfaces/MarketListing.ts
@@ -1,5 +1,7 @@
 import { AveragePrice } from './AveragePrice';
 import { Card } from './Card';
+import { Pack } from './Pack';
+import { Sticker } from './Sticker';
 
 export interface MarketListing {
     marketId: number;
@@ -11,5 +13,7 @@ export interface MarketListing {
     createdAt: Date | null;
 
     type: string;
-    card: Card;
+    card?: Card;
+    pack?: Pack;
+    sticker?: Sticker;
 }


### PR DESCRIPTION
BREAKING CHANGE: `card` property is no longer mandatory on MarketListing object as the listing can be of `sticker` or `pack` type.

To reproduce the issue:
```
epics.Market.getListings(2641, 1, "price", "pack")
.then(listings => console.log(listings[0]))
```
Expected result: outputs a listed pack on the market
Actual result: 
```
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'id' of undefined
    at Function.createCard (lib\client\utils\Card.js:13:22)
    at createMarketListing (lib\client\utils\Market.js:27:34)
```