### PR TITLE
feat: Allow to filter user listed items by type

### DIFF
--- a/src/client/actions/User.ts
+++ b/src/client/actions/User.ts
@@ -185,12 +185,14 @@ export default class User {
      * Get the market listings of a given user id
      * @param userId the user id to get its cards
      * @param page the page to get (1 page = 40 Market listings)
+     * @param type type of item listed (card|pack|sticker)
      * @returns a Promise resolved with the response or rejected in case of error
      */
-    public async getMarketListings(userId: number, page = 1): Promise<UserMarketListings> {
+    public async getMarketListings(userId: number, page = 1, type?: string): Promise<UserMarketListings> {
         const result = await this.baseClient.get(`market/listed/users/${userId}`, {
             userId,
             page,
+            type,
         });
 
         const data: UserMarketListings = {


### PR DESCRIPTION
I wonder whether an `enum` would be useful for available item types?

To test it:
```
epics.User.getMarketListings(userId, 1, "card")
.then(userListing => console.log(userListing.marketListings[0].type))
```
Expected output: the same item type as the one filtered in the `epics.User.getMarketListings` call